### PR TITLE
add missing math functions to function wrappers

### DIFF
--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -100,6 +100,8 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('tan');           //Arc tangent parameter in radians
 		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
 		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
+		$this->ctx->def('rand'); // random(lower bound, upper bound)
+
 
 		// non-php mathematical functions
 		$this->ctx->def('sgn', function($v) { if ($v == 0) return 0; return ($v > 0) ? 1 : -1; }); // signum

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -94,12 +94,6 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('sqrt');          //Square root
 		$this->ctx->def('sin');           //Sine parameter in radians
 		$this->ctx->def('cos');           //Cosine parameter in radians
-		$this->ctx->def('tan');           //Tangent parameter in radians
-		$this->ctx->def('asin');          //Arc sine parameter in radians
-		$this->ctx->def('acos');          //Arc cosine parameter in radians
-		$this->ctx->def('atan');          //Arc tangent parameter in radians
-		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
-		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
 		$this->ctx->def('rand');          //Random(lower bound, upper bound)
 
 
@@ -110,6 +104,10 @@ class VirtualInterpreter extends Interpreter {
 		// logical functions
 		$this->ctx->def('if', function($if, $then, $else = 0) { return $if ? $then : $else; });
 		$this->ctx->def('ifnull', function($if, $then) { return $if ?: $then; });
+		$this->ctx->def('or', function() { $res=false; foreach ( func_get_args() as $v ) $res = $res || $v; return $res; });
+		$this->ctx->def('and', function() { $res=true; foreach ( func_get_args() as $v ) $res = $res && $v; return $res; });
+
+		
 		$this->ctx->def('or', function($a,$b) { return $a || $b; });
 		$this->ctx->def('and', function($a,$b) { return $a && $b; });
 		

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -79,43 +79,19 @@ class VirtualInterpreter extends Interpreter {
 	 * Create static, non-data context functions
 	 */
 	protected function createStaticContextFunctions() {
-		// php function wrappers
-		// math functions (see php manual for arguments)
+		// php function wrappers (see php manual for arguments)
 		$this->ctx->def('abs');           //Absolute value
-		$this->ctx->def('acos');          //Arc cosine
-		$this->ctx->def('acosh');         //Inverse hyperbolic cosine
-		$this->ctx->def('asin');          //Arc sine
-		$this->ctx->def('asinh');         //Inverse hyperbolic sine
-		$this->ctx->def('atan2');         //Arc tangent of two variables
-		$this->ctx->def('atan');          //Arc tangent
-		$this->ctx->def('atanh');         //Inverse hyperbolic tangent
 		$this->ctx->def('ceil');          //Round fractions up
-		$this->ctx->def('cos');           //Cosine
-		$this->ctx->def('cosh');          //Hyperbolic cosine
-		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
 		$this->ctx->def('exp');           //Calculates the exponent of e
-		$this->ctx->def('expm1');         //Returns exp(number) - 1, computed in a way that is accurate even when the value of number is close to zero
 		$this->ctx->def('floor');         //Round fractions down
 		$this->ctx->def('fmod');          //Returns the floating point remainder (modulo) of the division of the arguments
-		$this->ctx->def('getrandmax');    //Show largest possible random value
-		$this->ctx->def('hypot');         //Calculate the length of the hypotenuse of a right-angle triangle
-		$this->ctx->def('lcg_value');     //Combined linear congruential generator
 		$this->ctx->def('log10');         //Base-10 logarithm
-		$this->ctx->def('log1p');         //Returns log(1 + number), computed in a way that is accurate even when the value of number is close to zero
 		$this->ctx->def('log');           //Natural logarithm
 		$this->ctx->def('max');           //Find highest value
 		$this->ctx->def('min');           //Find lowest value
-		$this->ctx->def('pi');            //Get value of pi
 		$this->ctx->def('pow');           //Exponential expression
-		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
-		$this->ctx->def('rand');          //Generate a random integer
 		$this->ctx->def('round');         //Rounds a float
-		$this->ctx->def('sin');           //Sine
-		$this->ctx->def('sinh');          //Hyperbolic sine
 		$this->ctx->def('sqrt');          //Square root
-		$this->ctx->def('srand');         //Seed the random number generator
-		$this->ctx->def('tan');           //Tangent
-		$this->ctx->def('tanh');          //Hyperbolic tangent
 		
 		// non-php mathematical functions
 		$this->ctx->def('sgn', function($v) { if ($v == 0) return 0; return ($v > 0) ? 1 : -1; }); // signum
@@ -124,14 +100,17 @@ class VirtualInterpreter extends Interpreter {
 		// logical functions
 		$this->ctx->def('if', function($if, $then, $else = 0) { return $if ? $then : $else; });
 		$this->ctx->def('ifnull', function($if, $then) { return $if ?: $then; });
-
+		$this->ctx->def('or', function($a,$b) { return $a || $b; });
+		$this->ctx->def('and', function($a,$b) { return $a && $b; });
+		
 		// date/time functions
 		$this->ctx->def('year', function($ts) { return (int) date('Y', (int) $ts); });
 		$this->ctx->def('month', function($ts) { return (int) date('n', (int) $ts); });
 		$this->ctx->def('day', function($ts) { return (int) date('d', (int) $ts); });
 		$this->ctx->def('hour', function($ts) { return (int) date('H', (int) $ts); });
 		$this->ctx->def('minutes', function($ts) { return (int) date('i', (int) $ts); });
-		$this->ctx->def('seconds', function($ts) { return (int) date('s', (int) $ts); });
+		$this->ctx->def('seconds', function($ts) { return (int) date('s', (int) $ts); });		
+		$this->ctx->def('weekday', function($ts) { return (int) date('N', (int) $ts); }); //1=Monday 7=Sunday
 	}
 
 	/**

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -89,36 +89,22 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('atan2');         //Arc tangent of two variables
 		$this->ctx->def('atan');          //Arc tangent
 		$this->ctx->def('atanh');         //Inverse hyperbolic tangent
-		$this->ctx->def('base_convert');  //Convert a number between arbitrary bases
-		$this->ctx->def('bindec');        //Binary to decimal
 		$this->ctx->def('ceil');          //Round fractions up
 		$this->ctx->def('cos');           //Cosine
 		$this->ctx->def('cosh');          //Hyperbolic cosine
-		$this->ctx->def('decbin');        //Decimal to binary
-		$this->ctx->def('dechex');        //Decimal to hexadecimal
-		$this->ctx->def('decoct');        //Decimal to octal
 		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
 		$this->ctx->def('exp');           //Calculates the exponent of e
 		$this->ctx->def('expm1');         //Returns exp(number) - 1, computed in a way that is accurate even when the value of number is close to zero
 		$this->ctx->def('floor');         //Round fractions down
 		$this->ctx->def('fmod');          //Returns the floating point remainder (modulo) of the division of the arguments
 		$this->ctx->def('getrandmax');    //Show largest possible random value
-		$this->ctx->def('hexdec');        //Hexadecimal to decimal
 		$this->ctx->def('hypot');         //Calculate the length of the hypotenuse of a right-angle triangle
-		$this->ctx->def('intdiv');        //Integer division
-		$this->ctx->def('is_finite');     //Finds whether a value is a legal finite number
-		$this->ctx->def('is_infinite');   //Finds whether a value is infinite
-		$this->ctx->def('is_nan');        //Finds whether a value is not a number
 		$this->ctx->def('lcg_value');     //Combined linear congruential generator
 		$this->ctx->def('log10');         //Base-10 logarithm
 		$this->ctx->def('log1p');         //Returns log(1 + number), computed in a way that is accurate even when the value of number is close to zero
 		$this->ctx->def('log');           //Natural logarithm
 		$this->ctx->def('max');           //Find highest value
 		$this->ctx->def('min');           //Find lowest value
-		$this->ctx->def('mt_getrandmax'); //Show largest possible random value
-		$this->ctx->def('mt_rand');       //Generate a random value via the Mersenne Twister Random Number Generator
-		$this->ctx->def('mt_srand');      //Seeds the Mersenne Twister Random Number Generator
-		$this->ctx->def('octdec');        //Octal to decimal
 		$this->ctx->def('pi');            //Get value of pi
 		$this->ctx->def('pow');           //Exponential expression
 		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -106,10 +106,6 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('ifnull', function($if, $then) { return $if ?: $then; });
 		$this->ctx->def('or', function() { $res=false; foreach ( func_get_args() as $v ) $res = $res || $v; return $res; });
 		$this->ctx->def('and', function() { $res=true; foreach ( func_get_args() as $v ) $res = $res && $v; return $res; });
-
-		
-		$this->ctx->def('or', function($a,$b) { return $a || $b; });
-		$this->ctx->def('and', function($a,$b) { return $a && $b; });
 		
 		// date/time functions
 		$this->ctx->def('year', function($ts) { return (int) date('Y', (int) $ts); });

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -80,13 +80,57 @@ class VirtualInterpreter extends Interpreter {
 	 */
 	protected function createStaticContextFunctions() {
 		// php function wrappers
-		$this->ctx->def('abs');
-		$this->ctx->def('min');
-		$this->ctx->def('max');
-		$this->ctx->def('sin');
-		$this->ctx->def('cos');
-		$this->ctx->def('rand'); // random(lower bound, upper bound)
-
+		// math functions (see php manual for arguments)
+		$this->ctx->def('abs');           //Absolute value
+		$this->ctx->def('acos');          //Arc cosine
+		$this->ctx->def('acosh');         //Inverse hyperbolic cosine
+		$this->ctx->def('asin');          //Arc sine
+		$this->ctx->def('asinh');         //Inverse hyperbolic sine
+		$this->ctx->def('atan2');         //Arc tangent of two variables
+		$this->ctx->def('atan');          //Arc tangent
+		$this->ctx->def('atanh');         //Inverse hyperbolic tangent
+		$this->ctx->def('base_convert');  //Convert a number between arbitrary bases
+		$this->ctx->def('bindec');        //Binary to decimal
+		$this->ctx->def('ceil');          //Round fractions up
+		$this->ctx->def('cos');           //Cosine
+		$this->ctx->def('cosh');          //Hyperbolic cosine
+		$this->ctx->def('decbin');        //Decimal to binary
+		$this->ctx->def('dechex');        //Decimal to hexadecimal
+		$this->ctx->def('decoct');        //Decimal to octal
+		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
+		$this->ctx->def('exp');           //Calculates the exponent of e
+		$this->ctx->def('expm1');         //Returns exp(number) - 1, computed in a way that is accurate even when the value of number is close to zero
+		$this->ctx->def('floor');         //Round fractions down
+		$this->ctx->def('fmod');          //Returns the floating point remainder (modulo) of the division of the arguments
+		$this->ctx->def('getrandmax');    //Show largest possible random value
+		$this->ctx->def('hexdec');        //Hexadecimal to decimal
+		$this->ctx->def('hypot');         //Calculate the length of the hypotenuse of a right-angle triangle
+		$this->ctx->def('intdiv');        //Integer division
+		$this->ctx->def('is_finite');     //Finds whether a value is a legal finite number
+		$this->ctx->def('is_infinite');   //Finds whether a value is infinite
+		$this->ctx->def('is_nan');        //Finds whether a value is not a number
+		$this->ctx->def('lcg_value');     //Combined linear congruential generator
+		$this->ctx->def('log10');         //Base-10 logarithm
+		$this->ctx->def('log1p');         //Returns log(1 + number), computed in a way that is accurate even when the value of number is close to zero
+		$this->ctx->def('log');           //Natural logarithm
+		$this->ctx->def('max');           //Find highest value
+		$this->ctx->def('min');           //Find lowest value
+		$this->ctx->def('mt_getrandmax'); //Show largest possible random value
+		$this->ctx->def('mt_rand');       //Generate a random value via the Mersenne Twister Random Number Generator
+		$this->ctx->def('mt_srand');      //Seeds the Mersenne Twister Random Number Generator
+		$this->ctx->def('octdec');        //Octal to decimal
+		$this->ctx->def('pi');            //Get value of pi
+		$this->ctx->def('pow');           //Exponential expression
+		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
+		$this->ctx->def('rand');          //Generate a random integer
+		$this->ctx->def('round');         //Rounds a float
+		$this->ctx->def('sin');           //Sine
+		$this->ctx->def('sinh');          //Hyperbolic sine
+		$this->ctx->def('sqrt');          //Square root
+		$this->ctx->def('srand');         //Seed the random number generator
+		$this->ctx->def('tan');           //Tangent
+		$this->ctx->def('tanh');          //Hyperbolic tangent
+		
 		// non-php mathematical functions
 		$this->ctx->def('sgn', function($v) { if ($v == 0) return 0; return ($v > 0) ? 1 : -1; }); // signum
 		$this->ctx->def('avg', function() { return (array_sum(func_get_args()) / func_num_args()); }); // avg

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -92,7 +92,15 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('pow');           //Exponential expression
 		$this->ctx->def('round');         //Rounds a float
 		$this->ctx->def('sqrt');          //Square root
-		
+		$this->ctx->def('sin');           //Sine parameter in radians
+		$this->ctx->def('cos');           //Cosine parameter in radians
+		$this->ctx->def('tan');           //Tangent parameter in radians
+		$this->ctx->def('sin');           //Arc sine parameter in radians
+		$this->ctx->def('cos');           //Arc cosine parameter in radians
+		$this->ctx->def('tan');           //Arc tangent parameter in radians
+		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
+		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
+
 		// non-php mathematical functions
 		$this->ctx->def('sgn', function($v) { if ($v == 0) return 0; return ($v > 0) ? 1 : -1; }); // signum
 		$this->ctx->def('avg', function() { return (array_sum(func_get_args()) / func_num_args()); }); // avg

--- a/lib/Interpreter/VirtualInterpreter.php
+++ b/lib/Interpreter/VirtualInterpreter.php
@@ -95,12 +95,12 @@ class VirtualInterpreter extends Interpreter {
 		$this->ctx->def('sin');           //Sine parameter in radians
 		$this->ctx->def('cos');           //Cosine parameter in radians
 		$this->ctx->def('tan');           //Tangent parameter in radians
-		$this->ctx->def('sin');           //Arc sine parameter in radians
-		$this->ctx->def('cos');           //Arc cosine parameter in radians
-		$this->ctx->def('tan');           //Arc tangent parameter in radians
+		$this->ctx->def('asin');          //Arc sine parameter in radians
+		$this->ctx->def('acos');          //Arc cosine parameter in radians
+		$this->ctx->def('atan');          //Arc tangent parameter in radians
 		$this->ctx->def('deg2rad');       //Converts the number in degrees to the radian equivalent
 		$this->ctx->def('rad2deg');       //Converts the radian number to the equivalent number in degrees
-		$this->ctx->def('rand'); // random(lower bound, upper bound)
+		$this->ctx->def('rand');          //Random(lower bound, upper bound)
 
 
 		// non-php mathematical functions


### PR DESCRIPTION
The functions added are described at http://php.net/manual/en/ref.math.php
Note: Some functions may have no sense in the volkszaehler environment like decbin but not provide them would potential limit the usage of virtual channels